### PR TITLE
Add humidity from external sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -22,11 +22,6 @@
             "type": "boolean",
             "required": false
         },
-        "useExternalSensor": {
-            "title": "Use external sensor? (requires direct access)",
-            "type": "boolean",
-            "required": false
-        },
         "simpleDuctless": {
             "title": "Show simple HeaterCooler accessory only?",
             "type": "boolean",

--- a/config.schema.json
+++ b/config.schema.json
@@ -22,6 +22,11 @@
             "type": "boolean",
             "required": false
         },
+        "useExternalSensor": {
+            "title": "Use external sensor? (requires direct access)",
+            "type": "boolean",
+            "required": false
+        },
         "simpleDuctless": {
             "title": "Show simple HeaterCooler accessory only?",
             "type": "boolean",

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -26,7 +26,6 @@ export class KumoPlatformAccessory_ductless {
   private lastquery;
 
   private directAccess;
-  private useExternalSensor;
 
   private historyService: fakegato.FakeGatoHistoryService;
 
@@ -35,8 +34,9 @@ export class KumoPlatformAccessory_ductless {
     private readonly accessory: PlatformAccessory,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
-    if (this.useExternalSensor) {
+
+    const useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    if (useExternalSensor) {
       this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
     }
 
@@ -85,7 +85,7 @@ export class KumoPlatformAccessory_ductless {
     this.Fan.setCharacteristic(this.platform.Characteristic.Name, 'Fan');
     this.PowerSwitch.setCharacteristic(this.platform.Characteristic.Name, 'Power');
 
-    this.Humdity = this.useExternalSensor && this.directAccess ? this.accessory.getService(
+    this.Humdity = useExternalSensor ? this.accessory.getService(
       this.platform.Service.HumiditySensor) || this.accessory.addService(this.platform.Service.HumiditySensor) : null;
 
     if (this.Humdity) {

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -33,10 +33,12 @@ export class KumoPlatformAccessory_ductless {
   constructor(
     private readonly platform: KumoHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
-    private readonly hasSensors: boolean,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = hasSensors;
+    this.useExternalSensor = this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    if (this.useExternalSensor) {
+      this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
+    }
 
     // determine device profile and additional sensors to tailor accessory to
     // the capabilities of the kumo device

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -360,6 +360,9 @@ export class KumoPlatformAccessory_ductless {
 
       if (ourSensor.battery) {
         this.Humdity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, ourSensor.battery < 10);
+        if (ourSensor.battery < 10) {
+          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial)
+        }
       }
     }
     this.Humdity.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, currentValue);

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -33,9 +33,10 @@ export class KumoPlatformAccessory_ductless {
   constructor(
     private readonly platform: KumoHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly hasSensors: boolean,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.platform.config.useExternalSensor;
+    this.useExternalSensor = hasSensors;
 
     // determine device profile and additional sensors to tailor accessory to
     // the capabilities of the kumo device

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -335,7 +335,7 @@ export class KumoPlatformAccessory_ductless {
       this.platform.log.debug('%s (queryDevice_Direct): success.', this.accessory.displayName);
 
       if (this.Humdity) {
-        this.platform.log.info('querying external sensors on %s', this.accessory.context.serial);
+        this.platform.log.debug('querying external sensors on %s', this.accessory.context.serial);
         const sensorData = await this.platform.kumo.queryDeviceSensors_Direct(this.accessory.context.serial);
         if (sensorData) {
           this.accessory.context.sensors = sensorData;
@@ -353,7 +353,7 @@ export class KumoPlatformAccessory_ductless {
       return;
     }
     let currentValue: number = <number>this.Humdity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value;
-    if (this.accessory.context.sensors.length) {
+    if (this.accessory.context.sensors && this.accessory.context.sensors.length) {
       const ourSensor = this.accessory.context.sensors[0];
       currentValue = ourSensor.humidity;
       this.platform.log.debug('setting humidity to %s', currentValue);

--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -35,7 +35,7 @@ export class KumoPlatformAccessory_ductless {
     private readonly accessory: PlatformAccessory,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    this.useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
     if (this.useExternalSensor) {
       this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
     }

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -30,9 +30,10 @@ export class KumoPlatformAccessory_ductless_simple {
   constructor(
     private readonly platform: KumoHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly hasSensors: boolean,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.platform.config.useExternalSensor;
+    this.useExternalSensor = hasSensors;
 
     // set accessory information
     if (accessory.context.zoneTable.unitType !== undefined && accessory.context.zoneTable.unitType !== null) {

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -7,7 +7,6 @@ import { KumoDevice, KumoDeviceDirect } from './kumo-api';
 import { KumoHomebridgePlatform } from './platform';
 
 import { KUMO_LAG, KUMO_DEVICE_WAIT } from './settings';
-import util from 'util';
 
 /*
  * Platform Accessory - Kumo 'ductless' accessory tested with a
@@ -17,7 +16,7 @@ import util from 'util';
  */
 export class KumoPlatformAccessory_ductless_simple {
   private HeaterCooler: Service;
-  private Humdity: Service | null;
+  private Humidity: Service | null;
 
   private lastupdate;
   private lastquery;
@@ -32,9 +31,14 @@ export class KumoPlatformAccessory_ductless_simple {
   ) {
     this.directAccess = this.platform.config.directAccess;
 
-    const useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    const useExternalSensor = this.directAccess &&
+      this.accessory.context.device.activeThermistor !== undefined &&
+      this.accessory.context.device.activeThermistor !== 'unset';
+
     if (useExternalSensor) {
-      this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
+      this.platform.log.info('device %s uses external sensor %s',
+        this.accessory.context.serial,
+        this.accessory.context.device.activeThermistor);
     }
 
     // set accessory information
@@ -54,14 +58,14 @@ export class KumoPlatformAccessory_ductless_simple {
     this.HeaterCooler = this.accessory.getService(
       this.platform.Service.HeaterCooler) || this.accessory.addService(this.platform.Service.HeaterCooler);
 
-    this.Humdity = useExternalSensor ? this.accessory.getService(
+    this.Humidity = useExternalSensor ? this.accessory.getService(
       this.platform.Service.HumiditySensor) || this.accessory.addService(this.platform.Service.HumiditySensor) : null;
 
     // set sevice names.
     this.HeaterCooler.setCharacteristic(this.platform.Characteristic.Name, 'Heater/Cooler');
 
-    if (this.Humdity) {
-      this.Humdity.setCharacteristic(this.platform.Characteristic.Name, 'Humidity Sensor');
+    if (this.Humidity) {
+      this.Humidity.setCharacteristic(this.platform.Characteristic.Name, 'Humidity Sensor');
     }
 
     // create handlers for characteristics
@@ -93,8 +97,8 @@ export class KumoPlatformAccessory_ductless_simple {
     this.HeaterCooler.getCharacteristic(this.platform.Characteristic.SwingMode)
       .on('set', this.handleFanSwingModeSet.bind(this));
 
-    if (this.Humdity) {
-      this.Humdity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+    if (this.Humidity) {
+      this.Humidity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
         .on('get', this.handleHumidityGet.bind(this));
     }
 
@@ -158,11 +162,11 @@ export class KumoPlatformAccessory_ductless_simple {
   }
 
   async handleHumidityGet(callback) {
-    if (!this.Humdity) {
+    if (!this.Humidity) {
       return;
     }
     await this.updateAccessoryCharacteristics();
-    callback(null, this.Humdity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value);
+    callback(null, this.Humidity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value);
   }
 
   async updateAccessoryCharacteristics() {
@@ -231,7 +235,7 @@ export class KumoPlatformAccessory_ductless_simple {
       }
       this.platform.log.debug('%s (queryDevice_Direct): success.');
 
-      if (this.Humdity) {
+      if (this.Humidity) {
         this.platform.log.debug('querying external sensors on %s', this.accessory.context.serial);
         const sensorData = await this.platform.kumo.queryDeviceSensors_Direct(this.accessory.context.serial);
         if (sensorData) {
@@ -355,23 +359,27 @@ export class KumoPlatformAccessory_ductless_simple {
   }
 
   private updateCurrentRelativeHumidity() {
-    if (!this.Humdity) {
+    if (!this.Humidity) {
       return;
     }
-    let currentValue: number = <number>this.Humdity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value;
+    let currentValue: number = <number>this.Humidity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value;
     if (this.accessory.context.sensors && this.accessory.context.sensors.length) {
       const ourSensor = this.accessory.context.sensors[0];
       currentValue = ourSensor.humidity;
       this.platform.log.debug('setting humidity to %s', currentValue);
 
       if (ourSensor.battery) {
-        this.Humdity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, ourSensor.battery < 10);
         if (ourSensor.battery < 10) {
           this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial)
+
+          this.Humidity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+        } else {
+          this.Humidity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
         }
+
       }
     }
-    this.Humdity.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, currentValue);
+    this.Humidity.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, currentValue);
   }
   
   private updateFanRotationSpeed() {

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -366,6 +366,9 @@ export class KumoPlatformAccessory_ductless_simple {
 
       if (ourSensor.battery) {
         this.Humdity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, ourSensor.battery < 10);
+        if (ourSensor.battery < 10) {
+          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial)
+        }
       }
     }
     this.Humdity.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, currentValue);

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -30,10 +30,12 @@ export class KumoPlatformAccessory_ductless_simple {
   constructor(
     private readonly platform: KumoHomebridgePlatform,
     private readonly accessory: PlatformAccessory,
-    private readonly hasSensors: boolean,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = hasSensors;
+    this.useExternalSensor = this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    if (this.useExternalSensor) {
+      this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
+    }
 
     // set accessory information
     if (accessory.context.zoneTable.unitType !== undefined && accessory.context.zoneTable.unitType !== null) {

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -232,7 +232,7 @@ export class KumoPlatformAccessory_ductless_simple {
       this.platform.log.debug('%s (queryDevice_Direct): success.');
 
       if (this.Humdity) {
-        this.platform.log.info('querying external sensors on %s', this.accessory.context.serial);
+        this.platform.log.debug('querying external sensors on %s', this.accessory.context.serial);
         const sensorData = await this.platform.kumo.queryDeviceSensors_Direct(this.accessory.context.serial);
         if (sensorData) {
           this.accessory.context.sensors = sensorData;
@@ -359,7 +359,7 @@ export class KumoPlatformAccessory_ductless_simple {
       return;
     }
     let currentValue: number = <number>this.Humdity.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity).value;
-    if (this.accessory.context.sensors.length) {
+    if (this.accessory.context.sensors && this.accessory.context.sensors.length) {
       const ourSensor = this.accessory.context.sensors[0];
       currentValue = ourSensor.humidity;
       this.platform.log.debug('setting humidity to %s', currentValue);

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -32,7 +32,7 @@ export class KumoPlatformAccessory_ductless_simple {
     private readonly accessory: PlatformAccessory,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    this.useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
     if (this.useExternalSensor) {
       this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
     }

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -23,7 +23,6 @@ export class KumoPlatformAccessory_ductless_simple {
   private lastquery;
 
   private directAccess;
-  private useExternalSensor;
 
   private historyService: fakegato.FakeGatoHistoryService;
 
@@ -32,8 +31,9 @@ export class KumoPlatformAccessory_ductless_simple {
     private readonly accessory: PlatformAccessory,
   ) {
     this.directAccess = this.platform.config.directAccess;
-    this.useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
-    if (this.useExternalSensor) {
+
+    const useExternalSensor = this.directAccess && this.accessory.context.device.activeThermistor !== undefined && this.accessory.context.device.activeThermistor !== "unset"
+    if (useExternalSensor) {
       this.platform.log.info('device %s uses external sensor %s', this.accessory.context.serial, this.accessory.context.device.activeThermistor)
     }
 
@@ -54,7 +54,7 @@ export class KumoPlatformAccessory_ductless_simple {
     this.HeaterCooler = this.accessory.getService(
       this.platform.Service.HeaterCooler) || this.accessory.addService(this.platform.Service.HeaterCooler);
 
-    this.Humdity = this.useExternalSensor && this.directAccess ? this.accessory.getService(
+    this.Humdity = useExternalSensor ? this.accessory.getService(
       this.platform.Service.HumiditySensor) || this.accessory.addService(this.platform.Service.HumiditySensor) : null;
 
     // set sevice names.

--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -63,6 +63,13 @@ interface KumoDeviceDirectInterface {
   vaneDir: string,
 }
 
+interface KumoSensorData {
+  battery: number;
+  humidity: number;
+  temperature: number;
+  uuid: string;
+}
+
 export type KumoDeviceDirect = Readonly<KumoDeviceDirectInterface>;
 
 // Renew Kumo security credentials every so often, in hours.
@@ -349,7 +356,7 @@ export class KumoApi {
     return true;
   }
 
-  // querying sensors (not implemented as not available to test)
+  // querying sensors
   async queryDeviceSensors_Direct(serial: string) {
     const data = await this.directRequest('{"c":{"sensors":{}}}', serial);
     if(!data){
@@ -357,14 +364,13 @@ export class KumoApi {
     }  
     this.log.debug(util.inspect(data, { colors: true, sorted: true, depth: 3 }));
 
-    const deviceSensors = [] as any;
+    const deviceSensors = [] as KumoSensorData[];
     try {
       const sensors = data.r.sensors;
       for(const sensor in sensors) {
         if(sensors[sensor].uuid !== null && sensors[sensor].uuid !== undefined) {
           this.log.debug('Found sensor.uuid: %s', sensors[sensor].uuid);
-          const uuid:string = sensors[sensor].uuid;
-          deviceSensors.push(uuid);
+          deviceSensors.push(<KumoSensorData>sensors[sensor]);
         }
       }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -132,12 +132,10 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if(existingAccessory.context.zoneTable.unitType === 'ductless' 
           || existingAccessory.context.zoneTable.unitType === 'mvz') {
           this.log.info('Initializing "%s" as ductless unit.', existingAccessory.displayName);
-          this.log.info('seeing if "%s" has a sensor attached', existingAccessory.displayName);
-          const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
           if(this.config.simpleDuctless) {
-            new KumoPlatformAccessory_ductless_simple(this, existingAccessory, hasSensors);
+            new KumoPlatformAccessory_ductless_simple(this, existingAccessory);
           } else {
-            new KumoPlatformAccessory_ductless(this, existingAccessory, hasSensors);
+            new KumoPlatformAccessory_ductless(this, existingAccessory);
           }
         } else {
           this.log.info('Initializing "%s" of unitType "%s" as generic (unspecified) unit.', 
@@ -150,12 +148,10 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
           if((existingAccessory.context.device.sp_heat !== undefined || existingAccessory.context.device.spHeat !== undefined) && (
             existingAccessory.context.device.sp_cool !== undefined || existingAccessory.context.device.spCool !== undefined)) {
             this.log.info('%s: Found heat and cool settings will use ductless accessory', existingAccessory.displayName);
-            this.log.info('seeing if "%s" has a sensor attached', existingAccessory.displayName);
-            const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
             if(this.config.simpleDuctless) {
-              new KumoPlatformAccessory_ductless_simple(this, existingAccessory, hasSensors);
+              new KumoPlatformAccessory_ductless_simple(this, existingAccessory);
             } else {
-              new KumoPlatformAccessory_ductless(this, existingAccessory, hasSensors);
+              new KumoPlatformAccessory_ductless(this, existingAccessory);
             }
           } else {         
             this.log.info('%s: Using platformaAccessory.ts accessory.', existingAccessory.displayName);
@@ -204,12 +200,10 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if(accessory.context.zoneTable.unitType === 'ductless' 
           || accessory.context.zoneTable.unitType === 'mvz') {
           this.log.info('Initializing "%s" as ductless unit.', device.label);
-          this.log.info('seeing if "%s" has a sensor attached', device.label);
-          const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
           if(this.config.simpleDuctless) {
-            new KumoPlatformAccessory_ductless_simple(this, accessory, hasSensors);
+            new KumoPlatformAccessory_ductless_simple(this, accessory);
           } else {
-            new KumoPlatformAccessory_ductless(this, accessory, hasSensors);
+            new KumoPlatformAccessory_ductless(this, accessory);
           }
         } else {
           this.log.info('Initializing "%s" of unitType "%s" as generic (unspecified) unit.', 
@@ -222,12 +216,10 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
           if((accessory.context.device.sp_heat !== undefined || accessory.context.device.spHeat !== undefined ) && (
             accessory.context.device.sp_cool !== undefined || accessory.context.device.spCool !== undefined )) {
             this.log.info('%s: Found heat and cool settings will use ductless accessory', accessory.displayName);
-            this.log.info('seeing if "%s" has a sensor attached', device.displayName);
-            const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
             if(this.config.simpleDuctless) {
-              new KumoPlatformAccessory_ductless_simple(this, accessory, hasSensors);
+              new KumoPlatformAccessory_ductless_simple(this, accessory);
             } else {
-              new KumoPlatformAccessory_ductless(this, accessory, hasSensors);
+              new KumoPlatformAccessory_ductless(this, accessory);
             }
           } else {         
             this.log.info('%s: Using platformaAccessory.ts accessory.', accessory.displayName);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -132,10 +132,12 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if(existingAccessory.context.zoneTable.unitType === 'ductless' 
           || existingAccessory.context.zoneTable.unitType === 'mvz') {
           this.log.info('Initializing "%s" as ductless unit.', existingAccessory.displayName);
+          this.log.info('seeing if "%s" has a sensor attached', existingAccessory.displayName);
+          const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
           if(this.config.simpleDuctless) {
-            new KumoPlatformAccessory_ductless_simple(this, existingAccessory);
+            new KumoPlatformAccessory_ductless_simple(this, existingAccessory, hasSensors);
           } else {
-            new KumoPlatformAccessory_ductless(this, existingAccessory);
+            new KumoPlatformAccessory_ductless(this, existingAccessory, hasSensors);
           }
         } else {
           this.log.info('Initializing "%s" of unitType "%s" as generic (unspecified) unit.', 
@@ -148,10 +150,12 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
           if((existingAccessory.context.device.sp_heat !== undefined || existingAccessory.context.device.spHeat !== undefined) && (
             existingAccessory.context.device.sp_cool !== undefined || existingAccessory.context.device.spCool !== undefined)) {
             this.log.info('%s: Found heat and cool settings will use ductless accessory', existingAccessory.displayName);
+            this.log.info('seeing if "%s" has a sensor attached', existingAccessory.displayName);
+            const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
             if(this.config.simpleDuctless) {
-              new KumoPlatformAccessory_ductless_simple(this, existingAccessory);
+              new KumoPlatformAccessory_ductless_simple(this, existingAccessory, hasSensors);
             } else {
-              new KumoPlatformAccessory_ductless(this, existingAccessory);
+              new KumoPlatformAccessory_ductless(this, existingAccessory, hasSensors);
             }
           } else {         
             this.log.info('%s: Using platformaAccessory.ts accessory.', existingAccessory.displayName);
@@ -200,10 +204,12 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if(accessory.context.zoneTable.unitType === 'ductless' 
           || accessory.context.zoneTable.unitType === 'mvz') {
           this.log.info('Initializing "%s" as ductless unit.', device.label);
+          this.log.info('seeing if "%s" has a sensor attached', device.label);
+          const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
           if(this.config.simpleDuctless) {
-            new KumoPlatformAccessory_ductless_simple(this, accessory);
+            new KumoPlatformAccessory_ductless_simple(this, accessory, hasSensors);
           } else {
-            new KumoPlatformAccessory_ductless(this, accessory);  
+            new KumoPlatformAccessory_ductless(this, accessory, hasSensors);
           }
         } else {
           this.log.info('Initializing "%s" of unitType "%s" as generic (unspecified) unit.', 
@@ -216,10 +222,12 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
           if((accessory.context.device.sp_heat !== undefined || accessory.context.device.spHeat !== undefined ) && (
             accessory.context.device.sp_cool !== undefined || accessory.context.device.spCool !== undefined )) {
             this.log.info('%s: Found heat and cool settings will use ductless accessory', accessory.displayName);
+            this.log.info('seeing if "%s" has a sensor attached', device.displayName);
+            const hasSensors = this.config.directAccess && await this.kumo.queryDeviceSensors_Direct(device.serial);
             if(this.config.simpleDuctless) {
-              new KumoPlatformAccessory_ductless_simple(this, accessory);
+              new KumoPlatformAccessory_ductless_simple(this, accessory, hasSensors);
             } else {
-              new KumoPlatformAccessory_ductless(this, accessory);
+              new KumoPlatformAccessory_ductless(this, accessory, hasSensors);
             }
           } else {         
             this.log.info('%s: Using platformaAccessory.ts accessory.', accessory.displayName);


### PR DESCRIPTION
This PR adds the ability to read the humidity from an external sensor (namely PAC-USWHS003-TH-1). There should not be any additional configuration needed to make this work, though it will only work if direct access is enabled. 

I only was able to do hacky testing of this for those without temperature sensors, because all of my units have sensors attached to them.