### PR TITLE
Allow users to specify an override IP address for direct access

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,16 @@ If you choose to configure this plugin directly instead of using the [Homebridge
 
 For most people, I recommend using [Homebridge Configuration web UI](https://github.com/oznu/homebridge-config-ui-x) to configure this plugin rather than doing so directly. It's easier to use for most users, especially newer users, and less prone to typos, leading to other problems.
 
+### Feature Options
+Special options are available by adding Feature Options, easily managable from the Plugin's settings via [Homebridge Configuration web UI](https://github.com/oznu/homebridge-config-ui-x). Only one option should be defined per Feature Option entry. The following options are available to be used: 
+
+- `Disable.[SerialNumber/ZoneName]`: Hide a specific device from being exposed in Homebridge. The device can be referenced by serial or zone name, both of which are printed out into the log when the plugin starts.
+- `Enable.[SerialNumber/ZoneName]`: Show a specific device from being exposed in Homebridge. The device can be referenced by serial or zone name, both of which are printed out into the log when the plugin starts.
+- `Address.[SerialNumber/ZoneName]=[IpAddress]`: Use a specific IP Address to connect to a given device (only applicable when Direct Access is enabled). The device can be referenced by serial or zone name, both of which are printed out into the log when the plugin starts.
+
 ### Troubleshooting
 
-1. Issue #45 (and others). If using directAccess, please ensure that the IP address assigned to your Kumo devices is static. The IP address is retrieved from the Kumo cloud at plugin startup and can become out of sync if the Wifi router reboots and assigns a new IP address. Until the Kumo cloud updates (which is unclear when this happens), the plugin will fail to connect.
+1. Issue #45 (and others). If using directAccess, please ensure that the IP address assigned to your Kumo devices is static. The IP address is retrieved from the Kumo cloud at plugin startup and can become out of sync if the Wifi router reboots and assigns a new IP address. Until the Kumo cloud updates (which is unclear when this happens), the plugin will fail to connect. If Kumo cloud seems to persistently have an incorrect IP Address, you may specify the IP Address the plugin should use to communicate with devices manually via the `Address.[SerialNumber/ZoneName]=[IpAddress]` feature option.
 
 2. Issue #42. There have been reports of time out errors occuring when using other plugins specifically homebridge-wemo. If you encounter a time out error, please move homebridge-kumo to a seperate bridge.
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -107,7 +107,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         existingAccessory.context.zoneTable = device.zoneTable;
         const overrideAddress = this.optionGetOverrideAddress(device, existingAccessory.context.zoneTable.address);
         if (overrideAddress != null) {
-        existingAccessory.context.zoneTable.address = overrideAddress;
+          existingAccessory.context.zoneTable.address = overrideAddress;
         }
         
         this.log.debug(device.zoneTable);
@@ -115,7 +115,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if (this.config.directAccess) {
           existingAccessory.context.device = await this.kumo.queryDevice_Direct(device.serial);
           if(existingAccessory.context.device === null) {
-            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, );
+            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, existingAccessory.context.zoneTable.address);
             existingAccessory.context.device = await this.kumo.queryDevice(device.serial);
             this.config.directAccess = false;
             this.log.info('Disabling directAccess to Kumo devices');

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -301,7 +301,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
 
     // We've explicitly set an address for this device.
     for (const configOption of this.config.options) {
-        if(!configOption.startsWith('address.' + (device.serial) + '=') && !configOption.startsWith('Address.' + (device.serial) + '=')) {
+        if(!configOption.startsWith('Address.' + (device.serial) + '=')) {
             continue;
         }
         return configOption.split('=')[1];
@@ -315,7 +315,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
 
     // We've explicitly set an address for the zoneTable label this device is attached to.
     for (const configOption of this.config.options) {
-        if(!configOption.startsWith('address.' + (device.label) + '=') && !configOption.startsWith('Address.' + (device.label) + '=')) {
+        if(!configOption.startsWith('Address.' + (device.label) + '=')) {
             continue;
         }
         return configOption.split('=')[1];

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -107,6 +107,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         existingAccessory.context.zoneTable = device.zoneTable;
         const overrideAddress = this.optionGetOverrideAddress(device, existingAccessory.context.zoneTable.address);
         if (overrideAddress != null) {
+          this.log.info('Override address found for device - using IP %s instead of %s for direct access', overrideAddress, existingAccessory.context.zoneTable.address);
           existingAccessory.context.zoneTable.address = overrideAddress;
         }
         
@@ -181,13 +182,18 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         // the `context` property can be used to store any data about the accessory you may need
         accessory.context.serial = device.serial;
         accessory.context.zoneTable = device.zoneTable;
+        const overrideAddress = this.optionGetOverrideAddress(device, accessory.context.zoneTable.address);
+        if (overrideAddress != null) {
+          this.log.info('Override address found for device - using IP %s instead of %s for direct access', overrideAddress, accessory.context.zoneTable.address);
+          accessory.context.zoneTable.address = overrideAddress;
+        }
         
         this.log.debug(device.zoneTable);
 
         if (this.config.directAccess) {
           accessory.context.device = await this.kumo.queryDevice_Direct(device.serial);
           if(accessory.context.device === null) {
-            this.log.error('Failed to connect to device IP (%s)', device.serial);
+            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, accessory.context.zoneTable.address);
             this.config.directAccess = false;
             this.log.info('Disabling directAccess to Kumo devices');
             accessory.context.device = await this.kumo.queryDevice(device.serial);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -300,9 +300,13 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
     }
 
     // We've explicitly set an address for this device.
-    if(this.config.options.indexOf('address.' + (device.serial)) !== -1) {
-      return this.config.options['address.' + (device.serial)];
+    for (const configOption of this.config.options) {
+        if(!configOption.startsWith('address.' + (device.serial) + '=')) {
+            continue;
+        }
+        return configOption.split('=')[1];
     }
+      
 
     // If we don't have a zoneTable label, we're done here.
     if(!device.label) {
@@ -310,8 +314,11 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
     }
 
     // We've explicitly set an address for the zoneTable label this device is attached to.
-    if(this.config.options.indexOf('address.' + device.label) !== -1) {
-      return this.config.options['address.' + (device.label)];
+    for (const configOption of this.config.options) {
+        if(!configOption.startsWith('address.' + (device.label) + '=')) {
+            continue;
+        }
+        return configOption.split('=')[1];
     }
 
     // Nothing special to do - return default.

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -301,7 +301,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
 
     // We've explicitly set an address for this device.
     for (const configOption of this.config.options) {
-        if(!configOption.startsWith('address.' + (device.serial) + '=')) {
+        if(!configOption.startsWith('address.' + (device.serial) + '=') && !configOption.startsWith('Address.' + (device.serial) + '=')) {
             continue;
         }
         return configOption.split('=')[1];
@@ -315,7 +315,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
 
     // We've explicitly set an address for the zoneTable label this device is attached to.
     for (const configOption of this.config.options) {
-        if(!configOption.startsWith('address.' + (device.label) + '=')) {
+        if(!configOption.startsWith('address.' + (device.label) + '=') && !configOption.startsWith('Address.' + (device.label) + '=')) {
             continue;
         }
         return configOption.split('=')[1];


### PR DESCRIPTION
I've run into an issue where KUMO cloud is out-of-sync with my network's IP Addresses (I swapped my Router out and wanted to make some changes to static assignments). It's been a few days, and addresses still haven't updated. It sounds like others in the community (kumo-hass) have experienced similar issues. This is my approach at allowing users to specify the manual IPs of their devices for cases when KUMO Cloud is out-of-sync and just won't sync up

- One can specify a direct address using address.[SERIAL]=IP.ADDRESS.HERE or address.[ZONE_NAME]=IP.ADDRESS.HERE
- Tested and verified this works locally