### PR TITLE
Improve fan speed controls

### DIFF
--- a/src/fanState.ts
+++ b/src/fanState.ts
@@ -1,0 +1,34 @@
+/** A fan state (speed) has multiple represenatations for use with different APIs. */
+export interface FanState {
+  /** Percent value used with HomeKit. */
+  percent: number,
+  /** Nueric index used with the Kumo cloud API. */
+  value: number,
+  /** Speed name used with the Kumo direct API. */
+  name: string,
+}
+export const fanStates: FanState[] = [
+  { percent: 0, value: 0, name: 'auto' },
+  { percent: 20, value: 1, name: 'superQuiet' },
+  { percent: 40, value: 2, name: 'quiet' },
+  { percent: 60, value: 3, name: 'low' },
+  //- not used - value: 4
+  { percent: 80, value: 5, name: 'powerful' },
+  { percent: 100, value: 6, name: 'superPowerful' },
+];
+
+/** Enables mapping between Kumo cloud, Kumo direct, and HomeKit representations of fan states. */
+export const fanStateMap: { [key in number | string]: FanState} = {};
+
+for (const fs of fanStates) {
+  fanStateMap[fs.value] = fs;
+  fanStateMap[fs.name] = fs;
+  fanStateMap[fs.percent] = fs;
+}
+
+/**
+ * Amount the HomeKit slider should "step". There are 5 speeds (aside from auto=0),
+ * so each speed is a 20 percent step.
+ * */
+export const fanPercentStep = 20;
+


### PR DESCRIPTION
This change makes the fan speed controls work better in a few ways:
 - The fan slider snaps to 20% increments, corresponding to the 5 fan speeds supported by the Kumo API.
 - The previous mapping from slider percent to Kumo API values would fail for part of the slider range due to the valid values being 0,1,2,3,5,6 (no 4). This is resolved.
 - When turning on the fan by setting it to active ("Hey Siri, turn on the Living Room AC Fan"), it now turns on to max speed instead of min speed. (Min speed is so slow and quiet that I assume nobody wants that as the default.)
 - When turning off heating/cooling, the system mode is set to fan if a specific fan speed had been set; otherwise the system power is turned off. Other interactions between fan speed, mode, and "active" states are improved as well.
 - With the above improvements to handling active states, the "Power" switch seemed redundant, so I removed it. Please review this choice, as I'm not sure if some people might have been using this switch in some way I'm not aware of.

I tested these changes with both direct and cloud APIs. Some additional verification from another user/developer might be helpful, since there are some complex interactions here.

All of the changes are applied only to the "ductless" device class. Some of the improvements could be ported to the "simple" or generic device classes; please advise if you think this is necessary.