### PR TITLE
Override chosen threshold temperature based on operating mode

### DIFF
--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -643,6 +643,13 @@ export class KumoPlatformAccessory_ductless {
 
   handleTargetHeaterCoolingThresholdTemperatureSet(value, callback) {
     const minCoolSetpoint: number = this.accessory.context.zoneTable.minCoolSetpoint;
+
+    if (this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState).value ===
+        this.platform.Characteristic.CurrentHeaterCoolerState.HEATING) {
+       this.platform.log.info('%s (Heater/Cooler): in heat mode but cooling threshold change requested; overriding', this.accessory.displayName);
+       this.handleTargetHeaterHeatingThresholdTemperatureSet(value, callback);
+       return;
+    }
     
     if(value<minCoolSetpoint) {
       value = minCoolSetpoint;
@@ -668,6 +675,13 @@ export class KumoPlatformAccessory_ductless {
 
   handleTargetHeaterHeatingThresholdTemperatureSet(value, callback) {
     const maxHeatSetpoint: number = this.accessory.context.zoneTable.maxHeatSetpoint;
+
+    if (this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState).value ===
+        this.platform.Characteristic.CurrentHeaterCoolerState.COOLING) {
+       this.platform.log.info('%s (Heater/Cooler): in cool mode but heating threshold change requested; overriding', this.accessory.displayName);
+       this.handleTargetHeaterCoolingThresholdTemperatureSet(value, callback);
+       return;
+    }
 
     if(value>maxHeatSetpoint) {
       value = maxHeatSetpoint;

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -510,6 +510,13 @@ export class KumoPlatformAccessory_ductless_simple {
 
   handleTargetHeaterCoolingThresholdTemperatureSet(value, callback) {
     const minCoolSetpoint: number = this.accessory.context.zoneTable.minCoolSetpoint;
+
+    if (this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState).value ===
+        this.platform.Characteristic.CurrentHeaterCoolerState.HEATING) {
+       this.platform.log.info('%s (Heater/Cooler): in heat mode but cooling threshold change requested; overriding', this.accessory.displayName);
+       this.handleTargetHeaterHeatingThresholdTemperatureSet(value, callback);
+       return;
+    }
     
     if(value<minCoolSetpoint) {
       value = minCoolSetpoint;
@@ -535,6 +542,13 @@ export class KumoPlatformAccessory_ductless_simple {
 
   handleTargetHeaterHeatingThresholdTemperatureSet(value, callback) {
     const maxHeatSetpoint: number = this.accessory.context.zoneTable.maxHeatSetpoint;
+
+    if (this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState).value ===
+        this.platform.Characteristic.CurrentHeaterCoolerState.COOLING) {
+       this.platform.log.info('%s (Heater/Cooler): in cool mode but heating threshold change requested; overriding', this.accessory.displayName);
+       this.handleTargetHeaterCoolingThresholdTemperatureSet(value, callback);
+       return;
+    }
 
     if(value>maxHeatSetpoint) {
       value = maxHeatSetpoint;


### PR DESCRIPTION
There is a longstanding Siri bug (#51) where Apple sets the wrong temperature threshold -- for example, in cooling mode a request to raise the temperature will change the heating setpoint instead if the requested temperature is higher than the current value.

Apple is notoriously indifferent to customers and developers, so it looks like we need to fix this ourselves.  