### PR TITLE
Fix Preserve override address between API refreshes

### DIFF
--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -185,6 +185,7 @@ export class KumoApi {
           serial: serial,
           label: zoneTable[serial].label,
           zoneTable: zoneTable[serial],
+          overrideAddress: null,
         };
         let existingDeviceIndex: string|number|undefined = undefined;
         for (const anExistingDeviceIndex in this.devices) {
@@ -436,12 +437,14 @@ export class KumoApi {
   // sends request
   private async directRequest(post_data: string, serial: string, attempt_number = 0) {
     let zoneTable; 
+    let overrideAddress;
     for (const device of this.devices) {
       if (device.serial === serial){
         zoneTable = device.zoneTable;
+        overrideAddress = device.overrideAddress;
       }
     }
-    const address: string = zoneTable.address;
+    const address: string = overrideAddress ?? zoneTable.address;
     const cryptoSerial: string = zoneTable.cryptoSerial; 
     const password: string = zoneTable.password; 
     

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,7 +108,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         const overrideAddress = this.optionGetOverrideAddress(device);
         if (overrideAddress !== null) {
           this.log.info('Override address found for device - using IP %s instead of %s for direct access', overrideAddress, existingAccessory.context.zoneTable.address);
-          existingAccessory.context.zoneTable.address = overrideAddress;
+          existingAccessory.context.overrideAddress = overrideAddress;
         }
         
         this.log.debug(device.zoneTable);
@@ -116,7 +116,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if (this.config.directAccess) {
           existingAccessory.context.device = await this.kumo.queryDevice_Direct(device.serial);
           if(existingAccessory.context.device === null) {
-            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, existingAccessory.context.zoneTable.address);
+            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, existingAccessory.context.overrideAddress ?? existingAccessory.context.zoneTable.address);
             existingAccessory.context.device = await this.kumo.queryDevice(device.serial);
             this.config.directAccess = false;
             this.log.info('Disabling directAccess to Kumo devices');
@@ -185,7 +185,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         const overrideAddress = this.optionGetOverrideAddress(device);
         if (overrideAddress !== null) {
           this.log.info('Override address found for device - using IP %s instead of %s for direct access', overrideAddress, accessory.context.zoneTable.address);
-          accessory.context.zoneTable.address = overrideAddress;
+          accessory.context.overrideAddress = overrideAddress;
         }
         
         this.log.debug(device.zoneTable);
@@ -193,7 +193,7 @@ export class KumoHomebridgePlatform implements DynamicPlatformPlugin {
         if (this.config.directAccess) {
           accessory.context.device = await this.kumo.queryDevice_Direct(device.serial);
           if(accessory.context.device === null) {
-            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, accessory.context.zoneTable.address);
+            this.log.error('Failed to connect to device IP (%s) at %s', device.serial, accessory.context.overrideAddress ?? accessory.context.zoneTable.address);
             this.config.directAccess = false;
             this.log.info('Disabling directAccess to Kumo devices');
             accessory.context.device = await this.kumo.queryDevice(device.serial);


### PR DESCRIPTION
Attempts to fix a regression introduced in my previous PR (https://github.com/fjs21/homebridge-kumo/pull/95)

Basically, the override address right now gets set by the Platform as an attribute of the zone table.
However, when an API refresh occurs, the zoneTable is flushed.

This PR instead makes overrideAddress a low-level property that's preserved between API refreshes.

Once again, not sure how to test this truly - and my last PR clearly wasn't error free!