### PR TITLE
Adjust temperature range of kumo accessories

### DIFF
--- a/src/ductless.ts
+++ b/src/ductless.ts
@@ -105,6 +105,30 @@ export class KumoPlatformAccessory_ductless {
       this.HumidityBattery.setCharacteristic(this.platform.Characteristic.ChargingState, this.platform.Characteristic.ChargingState.NOT_CHARGEABLE);
     }
 
+    const tempStep = 0.1;  
+    let minSetTemp: number, maxSetTemp: number, minGetTemp: number, maxGetTemp: number;
+    if (this.platform.kumo.isCelsiusUnits) {
+      minSetTemp = 9;
+      maxSetTemp = 32;
+      minGetTemp = -20;
+      maxGetTemp = 60;
+    } else {
+      minSetTemp = this.fahrenheitToCelsius(50);
+      maxSetTemp = this.fahrenheitToCelsius(90);
+      minGetTemp = this.fahrenheitToCelsius(0);
+      maxGetTemp = this.fahrenheitToCelsius(160);
+    }
+
+    // set temperature ranges
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .setProps({ minStep: tempStep, minValue: minGetTemp, maxValue: maxGetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+
     // create handlers for characteristics
     this.HeaterCooler.getCharacteristic(this.platform.Characteristic.Active)
       .on('get', this.handleActiveGet.bind(this))
@@ -843,6 +867,10 @@ export class KumoPlatformAccessory_ductless {
   private roundHalf(num: number) {
     return Math.round(num*2)/2;
   }
+
+  private fahrenheitToCelsius = function(temperature: number) {
+    return (temperature - 32) / 1.8;
+  };
 }
 
 

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -77,6 +77,34 @@ export class KumoPlatformAccessory_ductless_simple {
       this.HumidityBattery.setCharacteristic(this.platform.Characteristic.ChargingState, this.platform.Characteristic.ChargingState.NOT_CHARGEABLE);
     }
 
+    this.platform.log.info('Kumo is celsius:', this.platform.kumo.isCelsiusUnits); 
+    
+    const tempStep = 0.1;
+    
+    let minSetTemp: number, maxSetTemp: number, minGetTemp: number, maxGetTemp: number;
+    if (this.platform.kumo.isCelsiusUnits) {
+      minSetTemp = 9;
+      maxSetTemp = 32;
+      minGetTemp = -20;
+      maxGetTemp = 60;
+    } else {
+      minSetTemp = this.fahrenheitToCelsius(50);
+      maxSetTemp = this.fahrenheitToCelsius(90);
+      minGetTemp = this.fahrenheitToCelsius(0);
+      maxGetTemp = this.fahrenheitToCelsius(160);
+    }
+
+    // set temperature ranges
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .setProps({ minStep: tempStep, minValue: minGetTemp, maxValue: maxGetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.HeaterCooler.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+
+    
     // create handlers for characteristics
     this.HeaterCooler.getCharacteristic(this.platform.Characteristic.Active)
       .on('get', this.handleActiveGet.bind(this))
@@ -379,7 +407,7 @@ export class KumoPlatformAccessory_ductless_simple {
 
       if (ourSensor.battery) {
         if (ourSensor.battery < 10) {
-          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial)
+          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial);
 
           this.Humidity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
           this.HumidityBattery.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
@@ -618,4 +646,8 @@ export class KumoPlatformAccessory_ductless_simple {
   private roundHalf(num: number) {
     return Math.round(num*2)/2;
   }
+
+ private fahrenheitToCelsius = function(temperature: number) {
+   return (temperature - 32) / 1.8;
+ };
 }

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -404,7 +404,7 @@ export class KumoPlatformAccessory_ductless_simple {
 
       if (ourSensor.battery) {
         if (ourSensor.battery < 10) {
-          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial);
+          this.platform.log.warn('!!!The sensor attached to device %s has a low battery!!!', this.accessory.context.serial)
 
           this.Humidity.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
           this.HumidityBattery.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);

--- a/src/ductless_simple.ts
+++ b/src/ductless_simple.ts
@@ -77,10 +77,7 @@ export class KumoPlatformAccessory_ductless_simple {
       this.HumidityBattery.setCharacteristic(this.platform.Characteristic.ChargingState, this.platform.Characteristic.ChargingState.NOT_CHARGEABLE);
     }
 
-    this.platform.log.info('Kumo is celsius:', this.platform.kumo.isCelsiusUnits); 
-    
     const tempStep = 0.1;
-    
     let minSetTemp: number, maxSetTemp: number, minGetTemp: number, maxGetTemp: number;
     if (this.platform.kumo.isCelsiusUnits) {
       minSetTemp = 9;

--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -78,13 +78,14 @@ const KumoTokenExpirationWindow = KUMO_API_TOKEN_REFRESH_INTERVAL * 60 * 60 * 10
 export class KumoApi {
   //Devices!: Array<KumoDevice>;
   devices;
+  isCelsiusUnits!: boolean;
 
   private username: string;
   private password: string;
   private securityToken!: string;
   private securityTokenTimestamp!: number;
   private lastAuthenticateCall!: number;
-
+  
   private log: Logger;
 
   private headers = {
@@ -165,6 +166,9 @@ export class KumoApi {
     this.securityTokenTimestamp = now;
 
     this.log.debug('Token: %s', this.securityToken);
+
+    // Set the temperature units.
+    this.isCelsiusUnits = data[1].celsius;
 
     // Add the token to our headers that we will use for subsequent API calls.
     //this.headers.SecurityToken = this.securityToken;

--- a/src/kumo-api.ts
+++ b/src/kumo-api.ts
@@ -85,7 +85,7 @@ export class KumoApi {
   private securityToken!: string;
   private securityTokenTimestamp!: number;
   private lastAuthenticateCall!: number;
-  
+
   private log: Logger;
 
   private headers = {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -58,6 +58,12 @@ export class KumoPlatformAccessory {
     this.Fan.setCharacteristic(this.platform.Characteristic.Name, 'Fan');
     this.PowerSwitch.setCharacteristic(this.platform.Characteristic.Name, 'Power');
 
+    // set temperature ranges
+    this.Thermostat.getCharacteristic(this.platform.Characteristic.TargetTemperature).setProps({
+      minValue: 16,
+      maxValue: 30
+    });
+
     // create handlers for characteristics
     this.Thermostat.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
       .on('get', this.handleCurrentHeaterCoolerStateGet.bind(this));

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -58,11 +58,29 @@ export class KumoPlatformAccessory {
     this.Fan.setCharacteristic(this.platform.Characteristic.Name, 'Fan');
     this.PowerSwitch.setCharacteristic(this.platform.Characteristic.Name, 'Power');
 
+    const tempStep = 0.1;
+    let minSetTemp: number, maxSetTemp: number, minGetTemp: number, maxGetTemp: number;
+    if (this.platform.kumo.isCelsiusUnits) {
+      minSetTemp = 9;
+      maxSetTemp = 32;
+      minGetTemp = -20;
+      maxGetTemp = 60;
+    } else {
+      minSetTemp = this.fahrenheitToCelsius(50);
+      maxSetTemp = this.fahrenheitToCelsius(90);
+      minGetTemp = this.fahrenheitToCelsius(0);
+      maxGetTemp = this.fahrenheitToCelsius(160);
+    }
+
     // set temperature ranges
-    this.Thermostat.getCharacteristic(this.platform.Characteristic.TargetTemperature).setProps({
-      minValue: 16,
-      maxValue: 30
-    });
+    this.Thermostat.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .setProps({ minStep: tempStep, minValue: minGetTemp, maxValue: maxGetTemp });
+    this.Thermostat.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.Thermostat.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
+    this.Thermostat.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
+      .setProps({ minStep: tempStep, minValue: minSetTemp, maxValue: maxSetTemp });
 
     // create handlers for characteristics
     this.Thermostat.getCharacteristic(this.platform.Characteristic.CurrentHeaterCoolerState)
@@ -722,4 +740,8 @@ export class KumoPlatformAccessory {
   private roundHalf(num: number) {
     return Math.round(num*2)/2;
   }
+
+  private fahrenheitToCelsius = function(temperature: number) {
+    return (temperature - 32) / 1.8;
+  };
 }


### PR DESCRIPTION
When the Kumo heater/coolers are added to Homebridge and Apple Home they display a range that does not correspond to their operating temperatures and is unintuitive for control as reasonable requested temps are right at the top of the range (or even beyond it). Currently this range seems to be a Homebridge default of 0-25 C (32-77 F).

Before:
<img src="https://github.com/user-attachments/assets/b342ff20-ea00-4994-a78f-783522ee7c5a" width="128">

This change sets the min and max temperatures to more relevant values (9-32 C and 50-90 F) which also slightly reduces the range, making selecting your desired temperature easier using the slider.

As the Celsius and Fahrenheit ranges are slightly different, I read the units to use from the kumo cloud api.

After:
<img src="https://github.com/user-attachments/assets/48b3a4bc-d4a8-47d3-86b9-b584d14e9294" width="128">

I styled my code after the existing kumo accessories where logic is duplicated between them but am happy to refactor to reduce code duplication.

The temperature range implementation for this was based on the Nest Homebridge plugin's code for setting min and max temps. https://github.com/chrisjshull/homebridge-nest/blob/master/lib/nest-thermostat-accessory.js